### PR TITLE
Tweaked installation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@
 
 `npm install -g yo git+https://github.com/paypal/generator-webcore.git`
 
+Or, if you have already [set up your SSH key for use with GitHub](https://help.github.com/articles/generating-ssh-keys), you can use:
+
+`npm install -g yo git+ssh://git@github.com/paypal/generator-webcore.git`
+
 
 ### API
 


### PR DESCRIPTION
I made a slight tweak to the installation command. I didn't have ssh keys set up on public github, and I suspect others won't either. I did leave your original instruction, and pointed folks to the setup of SSH keys so that they can learn something.
