### PR TITLE
Implemented update checking with yeoman/update-notifier

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -24,13 +24,14 @@ var util = require('util'),
     path = require('path'),
     crypto = require('crypto'),
     yeoman = require('yeoman-generator'),
-    kraken = require('../lib/kraken');
-
+    kraken = require('../lib/kraken'),
+    update = require('../lib/update');
 
 var Generator = module.exports = function Generator(args, options, config) {
     yeoman.generators.Base.apply(this, arguments);
 
     kraken.banner();
+    update.check();
 
     this.hookFor('kraken:page', {
         args: ['index'].concat(args),

--- a/controller/index.js
+++ b/controller/index.js
@@ -22,11 +22,14 @@
 
 var util = require('util'),
     path = require('path'),
-    yeoman = require('yeoman-generator');
-
+    yeoman = require('yeoman-generator'),
+    update = require('../lib/update');
 
 var Generator = module.exports = function Generator(args, options, config) {
+
     yeoman.generators.NamedBase.apply(this, arguments);
+
+    update.check();
 
     this.auth = options.auth;
     this.json = options.json;

--- a/lib/update.js
+++ b/lib/update.js
@@ -1,0 +1,14 @@
+'use strict';
+
+var updateNotifier = require('update-notifier');
+
+module.exports.check = function check() {
+    var notifier = updateNotifier({
+        updateCheckInterval: 1000 * 60 * 60 * 24, // 1 day
+        packagePath: '../package.json'
+    });
+
+    if (notifier.update) {
+        notifier.notify();
+    }
+};

--- a/locale/index.js
+++ b/locale/index.js
@@ -22,7 +22,8 @@
 
 var util = require('util'),
     path = require('path'),
-    yeoman = require('yeoman-generator');
+    yeoman = require('yeoman-generator'),
+    update = require('../lib/update');
 
 
 var Generator = module.exports = function Generator(args, options, config) {
@@ -30,6 +31,8 @@ var Generator = module.exports = function Generator(args, options, config) {
         lang = args[2] || 'en';
 
     yeoman.generators.NamedBase.apply(this, arguments);
+
+    update.check();
 
     this.country = country.toUpperCase();
     this.lang = lang.toLowerCase();

--- a/model/index.js
+++ b/model/index.js
@@ -22,11 +22,13 @@
 
 var util = require('util'),
     path = require('path'),
-    yeoman = require('yeoman-generator');
+    yeoman = require('yeoman-generator'),
+    update = require('../lib/update');
 
 
 var Generator = module.exports = function Generator(args, options, config) {
     yeoman.generators.NamedBase.apply(this, arguments);
+    update.check();
 };
 
 

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "chalk": "~0.3.0"
   },
   "devDependencies": {
-    "mocha": "~1.12.0"
+    "mocha": "~1.12.0",
+    "update-notifier": "~0.1.7"
   },
   "peerDependencies": {
     "yo": ">=1.0.0-rc.1"

--- a/page/index.js
+++ b/page/index.js
@@ -21,11 +21,13 @@
 
 
 var util = require('util'),
-    yeoman = require('yeoman-generator');
-
+    yeoman = require('yeoman-generator'),
+    update = require('../lib/update');
 
 var Generator = module.exports = function Generator(args, options, config) {
     yeoman.generators.NamedBase.apply(this, arguments);
+
+    update.check();
 
     this.hookFor('kraken:controller', {
         args: args,

--- a/template/index.js
+++ b/template/index.js
@@ -22,11 +22,14 @@
 
 var util = require('util'),
     path = require('path'),
-    yeoman = require('yeoman-generator');
+    yeoman = require('yeoman-generator'),
+    update = require('../lib/update');
 
 
 var Generator = module.exports = function Generator(args, options, config) {
     yeoman.generators.NamedBase.apply(this, arguments);
+
+    update.check();
 };
 
 


### PR DESCRIPTION
Fixes #24 - Implemented update checking with yeoman/update-notifier

Unfortunately, yeoman is _too_ magical.  It seems to walk through your directories calling any function that isn't private and doesn't allow any global hooks for you to put common code across generators.  Sooo... I had to add the update check to every generator.

To test this locally:
1. `npm link` to swap out your global version with this version
2. Change package.json's version to 0.0.0 (less than the current version 0.0.1)
3. Run some generator commands like `yo kraken:controller test`.  To keep the generator speedy, updates are only checked once a day.  To change this setting for local testing, modify lib/update.js

Let me know if you'd like some mocha tests.  It'd be a bit tricky.  I'd probably have to spawn a child_process, then capture stdout and look for the update notification.
