### PR TITLE
fix bug that crashes cause of missing module update-notifier

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,11 +25,11 @@
   },
   "dependencies": {
     "yeoman-generator": "~0.13.0",
-    "chalk": "~0.3.0"
+    "chalk": "~0.3.0",
+    "update-notifier": "~0.1.7"
   },
   "devDependencies": {
-    "mocha": "~1.12.0",
-    "update-notifier": "~0.1.7"
+    "mocha": "~1.12.0"
   },
   "peerDependencies": {
     "yo": ">=1.0.0-rc.1"


### PR DESCRIPTION
The generator crash since it cannot find module update-notifier.
Update-notifer should be a dependencie not devdependencie.

Happy holidays!

http://www.freechristmaswallpapers.net/images/wallpapers/600x470-Christmas-Cat-01wallpapers-82992.jpg
