### PR TITLE
Add help pages for generators

### DIFF
--- a/app/USAGE
+++ b/app/USAGE
@@ -1,0 +1,5 @@
+Description:
+    Creates a new Kraken application.
+
+Example:
+    yo kraken

--- a/controller/USAGE
+++ b/controller/USAGE
@@ -1,0 +1,9 @@
+Description:
+    Creates a new controller.
+
+Example:
+    yo kraken:controller <name>
+
+    This will create:
+        controllers/<name>.js: Your controller.
+        test/<name>.js: Unit tests for your controller.

--- a/locale/USAGE
+++ b/locale/USAGE
@@ -1,0 +1,13 @@
+Description:
+    Creates a content bundle.
+
+Example:
+    yo kraken:locale <name> [<country>] [<language>]
+
+    "country" and "language" are optional.
+
+    If "country" is not specified, it will default to "US".
+    If "language" is not specified, it will default to "en".
+
+    This will create:
+        locales/<country>/<language>/<name>.js: Your content bundle.

--- a/locale/index.js
+++ b/locale/index.js
@@ -25,15 +25,27 @@ var util = require('util'),
 
 
 var Generator = module.exports = function Generator(args, options, config) {
-    var country = args[1] || 'US',
-        lang = args[2] || 'en';
-
     yeoman.generators.NamedBase.apply(this, arguments);
 
-    update.check();
+    var country = args[1] || 'US',
+        language = args[2] || 'en';
+
+    this.argument('country', {
+        optional: true,
+        required: false,
+        type: String
+    });
+
+    this.argument('language', {
+        optional: true,
+        required: false,
+        type: String
+    });
 
     this.country = country.toUpperCase();
-    this.lang = lang.toLowerCase();
+    this.language = language.toLowerCase();
+
+    update.check();
 };
 
 
@@ -41,5 +53,5 @@ util.inherits(Generator, yeoman.generators.NamedBase);
 
 
 Generator.prototype.files = function files() {
-    this.template('index.properties', path.join('locales', this.country, this.lang, this.name + '.properties'));
+    this.template('index.properties', path.join('locales', this.country, this.language, this.name + '.properties'));
 };

--- a/model/USAGE
+++ b/model/USAGE
@@ -1,0 +1,8 @@
+Description:
+    Creates a new model.
+
+Example:
+    yo kraken:model <name>
+
+    This will create:
+        models/<name>.js: Your model.

--- a/package.json
+++ b/package.json
@@ -24,12 +24,12 @@
     "test": "mocha"
   },
   "dependencies": {
-    "yeoman-generator": "~0.13.0",
+    "yeoman-generator": "~0.14.0",
     "chalk": "~0.3.0",
     "update-notifier": "~0.1.7"
   },
   "devDependencies": {
-    "mocha": "~1.12.0"
+    "mocha": "~1.14.0"
   },
   "peerDependencies": {
     "yo": ">=1.0.0-rc.1"

--- a/page/USAGE
+++ b/page/USAGE
@@ -1,0 +1,12 @@
+Description:
+    Creates a new controller, model, content bundle, and template.
+
+Example:
+    yo kraken:page <name>
+
+    This will create:
+        controllers/<name>.js: Your controller.
+        test/<name>.js: Unit tests for your controller.
+        models/<name>.js: Your model.
+        public/templates/<name>.dust: Your template.
+        locales/<country>/<locale>/<name>.js: Your content bundle.

--- a/template/USAGE
+++ b/template/USAGE
@@ -1,0 +1,9 @@
+Description:
+    Creates a new template.
+
+Example:
+    yo kraken:template <name>
+
+    This will create:
+        public/templates/<name>.dust: Your template.
+


### PR DESCRIPTION
- Added USAGE files to the main generator and subgenerator directories so yeoman can generate help pages (via the --help flag).  
- Using new this.argument() API in locale/index.js to add optional props while using the NamedBase generator.

Tests are passing.  This PR requires a newer generator-yeoman 0.14.0 and assumes that #29 has been merged.
