### PR TITLE
Better Error Messages

### DIFF
--- a/app/templates/index.js
+++ b/app/templates/index.js
@@ -29,7 +29,7 @@ app.requestAfterRoute = function requestAfterRoute(server) {
 if (require.main === module) {
     kraken.create(app).listen(function (err) {
         if (err) {
-            console.error(err);
+            console.error(err.stack);
         }
     });
 }


### PR DESCRIPTION
Currently when you try to startup a kraken that has some controllers with bad JavaScript, you get a pretty measily error message:
`[ReferenceError: server is not defined]`

With this change you get a message similar to the message one would get with node.js:

```
ReferenceError: server is not defined
    at Object.<anonymous> (/Users/jamuferguson/dev/paypal/8ballUI/controllers/extendSession.js:26:1)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Module.require (module.js:364:17)
    at require (module.js:380:17)
    at /Users/jamuferguson/dev/paypal/8ballUI/node_modules/kraken-js/node_modules/express-enrouten/index.js:85:35
    at Array.forEach (native)
    at Object.withRoutes (/Users/jamuferguson/dev/paypal/8ballUI/node_modules/kraken-js/node_modules/express-enrouten/index.js:83:41)
```
