### PR TITLE
Make sure the tests get the newly created page

### DIFF
--- a/controller/templates/_test.js
+++ b/controller/templates/_test.js
@@ -29,13 +29,12 @@ describe('<%= _.slugify(name) %>', function () {
 
     it('should say "hello"', function (done) {
         request(mock)
-            .get('/')
+            .get('/<% if (name !== "index") { %><%= _.slugify(name) %><% } %>')
             .expect(200)
             .expect('Content-Type', /html/)
             .expect(/Hello, /)
             .end(function(err, res){
-                if (err) return done(err);
-                done()
+                done(err);
             });
     });
 


### PR DESCRIPTION
Currently, all gen'd tests were checking against `/`
This PR makes sure that the gen'd tests check against the gen'd page.
(eg: `/pageName`)

Also simplifies error handling slightly.
