### PR TITLE
Moving delegate to separate module so it can be exported; Fixes #35

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -129,6 +129,7 @@ Generator.prototype.app = function app() {
 
 Generator.prototype.projectfiles = function projectfiles() {
     this.copy('index.js', 'index.js');
+    this.copy('delegate.js', 'delegate.js');
     this.copy('gitignore', '.gitignore');
     this.copy('nodemonignore', '.nodemonignore');
     this.copy('jshintignore', '.jshintignore');

--- a/app/templates/delegate.js
+++ b/app/templates/delegate.js
@@ -1,0 +1,26 @@
+'use strict';
+
+
+module.exports = {
+
+    configure: function configure(nconf, next) {
+        // Async method run on startup
+        next(null);
+    },
+
+
+    requestStart: function requestStart(server) {
+        // Run before most express middleware has been registered
+    },
+
+
+    requestBeforeRoute: function requestBeforeRoute(server) {
+        // Run before any routes have been added
+    },
+
+
+    requestAfterRoute:  function requestAfterRoute(server) {
+        // Run after all routes have been added
+    }
+
+};

--- a/app/templates/index.js
+++ b/app/templates/index.js
@@ -2,37 +2,11 @@
 
 
 var kraken = require('kraken-js'),
-    app = {};
+    delegate = require('./delegate');
 
 
-app.configure = function configure(nconf, next) {
-    // Async method run on startup.
-    next(null);
-};
-
-
-app.requestStart = function requestStart(server) {
-    // Run before most express middleware has been registered.
-};
-
-
-app.requestBeforeRoute = function requestBeforeRoute(server) {
-    // Run before any routes have been added.
-};
-
-
-app.requestAfterRoute = function requestAfterRoute(server) {
-    // Run after all routes have been added.
-};
-
-
-if (require.main === module) {
-    kraken.create(app).listen(function (err) {
-        if (err) {
-            console.error(err.stack);
-        }
-    });
-}
-
-
-module.exports = app;
+kraken.create(delegate).listen(function (err) {
+    if (err) {
+        console.error(err.stack);
+    }
+});

--- a/controller/templates/_test.js
+++ b/controller/templates/_test.js
@@ -3,10 +3,9 @@
 'use strict';
 
 
-var app = require('../index'),
+var app = require('../delegate'),
     kraken = require('kraken-js'),
-    request = require('supertest'),
-    assert = require('assert');
+    request = require('supertest');
 
 
 describe('<%= _.slugify(name) %>', function () {

--- a/test/app.js
+++ b/test/app.js
@@ -65,6 +65,7 @@ describe('App', function () {
                 'README.md',
                 'bower.json',
                 'index.js',
+                'delegate.js',
                 'package.json',
                 'config/app.json',
                 'config/middleware.json',


### PR DESCRIPTION
I was considering using `require.main.filename` which works in forever and a few others, but to get it to work in pm2 is tricky. Instead, I opted to just move the delegate lifecycle functions to their own file. 

This way it's clearer on the intended use of the file: `index.js` runs the app`and`delegate.js` exports the lifecycle functions.
