### PR TITLE
Dust templates are registered under the wrong name in win_32.

### DIFF
--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -53,7 +53,9 @@ module.exports = function (grunt) {
                     fullname: function (filepath) {
                         var path = require('path'),
                             name = path.basename(filepath, '.dust'),
-                        //Hardcoded to forwards slash on purpose. Keeps compatibility on win_32
+                        //Hardcoded to forwards slash on purpose. This is due to the way that grunt handles globbing.
+                        //Patterns like **/*.dust are always expanded using '/' with no consideration to the host OS
+                        //separator. This caused issues when trying to build on win_32
                             parts = filepath.split('/'),
                             fullname = parts.slice(3, -1).concat(name);
 


### PR DESCRIPTION
Grunt expands with hardcoded forward slashes, so using the host OS path separator actually causes errors :(

Hardcoding to forward slashes fixes it.
