### PR TITLE
Fix controller generator so it's compatible with IE8/9 out-of-the-box.

### DIFF
--- a/controller/templates/_controller.js
+++ b/controller/templates/_controller.js
@@ -11,14 +11,12 @@ module.exports = function (app) {
 
     app.get('/<% if (name !== "index") { %><%= _.slugify(name) %><% } %>', function (req, res) {
         <% if (json) { %>
-        res.format({
-            json: function () {
-                res.json(model);
-            },
-            html: function () {
-                res.render('<%= _.slugify(name) %>', model);
-            }
-        });<% } else { %>
+        if (req.xhr && req.accepts('json')) {
+            res.json(model);
+        } else {
+            res.render('<%= _.slugify(name) %>', model);
+        }
+        <% } else { %>
         res.render('<%= _.slugify(name) %>', model);
         <% } %>
     });

--- a/test/controller.js
+++ b/test/controller.js
@@ -60,7 +60,7 @@ describe('Controller', function () {
         options.prompt.json = true;
         runGenerator(options, function (err) {
             helpers.assertFiles([
-                ['controllers/Foo.js', /res.format/]
+                ['controllers/Foo.js', /req.xhr/]
             ]);
 
             done(err);


### PR DESCRIPTION
In IE8 and IE9, a typical Accept header for a plain GET request is:  `"image/jpeg, application/x-ms-application, image/gif, application/xaml+xml, image/pjpeg, application/x-ms-xbap, */*"`

Unfortunately kraken controllers with the option to respond to XHR requests are causing a ruckus.  Just a gosh darn ruckus, if you ask me.

A simple GET request to another route (clicking a link from the index page to another page) will resolve that accept header to json, which causes the browser to show a download pop up, rather than send back HTML.

The issue is that wildcard at the end.  `*/*` falls back to the json directive.

Referencing this express issue:  https://github.com/visionmedia/express/pull/1020
It's over a year old, but the general response is that IE8 is to blame.

Instead of using res.format, let's fallback to checking for xhr and the mime type ourselves.  I tested it and this fixes the problem in IE8 and 9.

Btw, `req.accepts('json')` is a shortcut for application/json.

![ROOMBA](http://moar.edgecats.net/cats/anigif_enhanced-buzz-10181-1323295518-9.gif)