### PR TITLE
Fix tests to not use deprecated yeoman functions.

### DIFF
--- a/test/app.js
+++ b/test/app.js
@@ -15,7 +15,7 @@
  │   See the License for the specific language governing permissions and       │
  │   limitations under the License.                                            │
  \*───────────────────────────────────────────────────────────────────────────*/
-/*global describe, beforeEach, it*/
+/*global describe, it*/
 
 'use strict';
 
@@ -34,7 +34,7 @@ describe('App', function () {
     it('creates dot files', function (done) {
         var options = new BaseOptions('app');
         runGenerator(options, function (err) {
-            helpers.assertFiles([
+            helpers.assertFile([
                 '.bowerrc',
                 '.editorconfig',
                 '.gitignore',
@@ -52,7 +52,7 @@ describe('App', function () {
     it('creates project files', function (done) {
         var options = new BaseOptions('app');
         runGenerator(options, function (err) {
-            helpers.assertFiles([
+            helpers.assertFile([
                 'Gruntfile.js',
                 'README.md',
                 'bower.json',
@@ -82,9 +82,12 @@ describe('App', function () {
         options.prompt.requireJs = true;
 
         runGenerator(options, function (err) {
-            helpers.assertFiles([
-                ['public/templates/layouts/master.dust', /require\.js/],
-                ['public/js/app.js', /require\(/],
+            helpers.assertFileContent([
+                ['public/templates/layouts/master.dust', new RegExp(/require\.js/)],
+                ['public/js/app.js', new RegExp(/require\(/)]
+            ]);
+
+            helpers.assertFile([
                 'public/js/config.js'
             ]);
 
@@ -141,7 +144,7 @@ describe('App', function () {
         runGenerator(options, function (err) {
 
             if (err) {
-              return  done(err);
+                return done(err);
             }
 
             //Launch `grunt build`

--- a/test/controller.js
+++ b/test/controller.js
@@ -15,7 +15,7 @@
 │   See the License for the specific language governing permissions and       │
 │   limitations under the License.                                            │
 \*───────────────────────────────────────────────────────────────────────────*/
-/*global describe, beforeEach, it*/
+/*global describe, it*/
 
 'use strict';
 
@@ -36,7 +36,7 @@ describe('Controller', function () {
 
     it('creates new controllers', function (done) {
         runGenerator(options, function (err) {
-            helpers.assertFiles([
+            helpers.assertFile([
                 'controllers/Foo.js'
             ]);
 
@@ -47,7 +47,7 @@ describe('Controller', function () {
 
     it('creates new tests', function (done) {
         runGenerator(options, function (err) {
-            helpers.assertFiles([
+            helpers.assertFile([
                 'test/Foo.js'
             ]);
 
@@ -59,8 +59,8 @@ describe('Controller', function () {
     it('creates new XHR enabled controllers', function (done) {
         options.prompt.json = true;
         runGenerator(options, function (err) {
-            helpers.assertFiles([
-                ['controllers/Foo.js', /res.format/]
+            helpers.assertFileContent([
+                ['controllers/Foo.js', new RegExp(/res.format/)]
             ]);
 
             done(err);

--- a/test/locale.js
+++ b/test/locale.js
@@ -15,7 +15,7 @@
 │   See the License for the specific language governing permissions and       │
 │   limitations under the License.                                            │
 \*───────────────────────────────────────────────────────────────────────────*/
-/*global describe, beforeEach, it*/
+/*global describe, it*/
 
 'use strict';
 
@@ -31,13 +31,13 @@ describe('Locale', function () {
     options.dependencies = [
         '../../locale'
     ];
-    options.prompt= {};
+    options.prompt = {};
 
 
     it('creates new locales', function (done) {
         options.args = ['Foo', 'DE', 'de'];
         runGenerator(options, function (err) {
-            helpers.assertFiles([
+            helpers.assertFile([
                 'locales/DE/de/Foo.properties'
             ]);
 
@@ -49,7 +49,7 @@ describe('Locale', function () {
     it('creates default locales as en_US', function (done) {
         options.args = ['Bar'];
         runGenerator(options, function (err) {
-            helpers.assertFiles([
+            helpers.assertFile([
                 'locales/US/en/Bar.properties'
             ]);
 

--- a/test/model.js
+++ b/test/model.js
@@ -15,7 +15,7 @@
 │   See the License for the specific language governing permissions and       │
 │   limitations under the License.                                            │
 \*───────────────────────────────────────────────────────────────────────────*/
-/*global describe, beforeEach, it*/
+/*global describe, it*/
 
 'use strict';
 
@@ -37,8 +37,8 @@ describe('Model', function () {
     it('creates new models', function (done) {
         options.args = ['Foo'];
         runGenerator(options, function (err) {
-            helpers.assertFiles([
-                ['models/Foo.js', /FooModel\(\)/]
+            helpers.assertFileContent([
+                ['models/Foo.js', new RegExp(/FooModel\(\)/)]
             ]);
 
             done(err);
@@ -49,11 +49,11 @@ describe('Model', function () {
     it('properly deals with slugged names', function (done) {
         options.args = ['foo-bar'];
         runGenerator(options, function (err) {
-            helpers.assertFiles([
-                ['models/foo-bar.js', /FooBarModel\(\)/]
+            helpers.assertFileContent([
+                ['models/foo-bar.js', new RegExp(/FooBarModel\(\)/)]
             ]);
 
-            done();
+            done(err);
         });
     });
 

--- a/test/template.js
+++ b/test/template.js
@@ -15,7 +15,7 @@
 │   See the License for the specific language governing permissions and       │
 │   limitations under the License.                                            │
 \*───────────────────────────────────────────────────────────────────────────*/
-/*global describe, beforeEach, it*/
+/*global describe, it*/
 
 'use strict';
 
@@ -37,7 +37,7 @@ describe('Template', function () {
 
     it('creates new templates', function (done) {
         runGenerator(options, function (err) {
-            helpers.assertFiles([
+            helpers.assertFile([
                 'public/templates/Foo.dust'
             ]);
 


### PR DESCRIPTION
Fixed unit tests so they don't use deprecated yeoman test helper functions.

Saw these two errors when running the unit tests:
`assert.files deprecated. Use assert.file([String, String, ...]) or assert.file([[String, RegExp], [String, RegExp]...]) instead.`

`assert.file(String, RegExp) DEPRECATED; use assert.fileContent(String, RegExp) instead.`

and fixed some formatting and dead lint directives.

![bowling is kool](http://i.imgur.com/1k8Q4BC.gif)
