### PR TITLE
adding specific patch versions of makara/adaro because windows fails to ...

### DIFF
--- a/app/dependencies.js
+++ b/app/dependencies.js
@@ -11,8 +11,8 @@ module.exports = {
         "npm": [
             "dustjs-linkedin@^2.0.3",
             "dustjs-helpers@^1.1.1",
-            "adaro@^0.1.0",
-            "makara@^0.3.0"
+            "adaro@^0.1.5",
+            "makara@^0.3.4"
         ],
         "npmDev": [
             "grunt-dustjs@^1.2.0"


### PR DESCRIPTION
...find the appropriate patch version when version listed wasn't actually published
