### PR TITLE
Fix typo on sass task.

### DIFF
--- a/app/templates/dependencies/sass/tasks/sass.js
+++ b/app/templates/dependencies/sass/tasks/sass.js
@@ -9,7 +9,7 @@ module.exports = function sass(grunt) {
 	return {
         build: {
             options: {
-                style: 'compressed'
+                outputStyle: 'compressed'
             },
             files: [{
                 expand: true,


### PR DESCRIPTION
With grunt-sass there is [no option value `style`](https://github.com/sindresorhus/grunt-sass#api) the correct one is `outputStyle`.
So sass files are not being preprocessed as compressed.

I think the confusion came from the grunt-contrib-sass which [uses `style`](https://github.com/gruntjs/grunt-contrib-sass#style) for the same option value.
