### PR TITLE
Update the development.json file to also watch for bower components

### DIFF
--- a/app/templates/common/config/development.json
+++ b/app/templates/common/config/development.json
@@ -43,7 +43,7 @@
                         },<% } %><% if (cssModule) { %>
                         "css": {
                             "module": "kraken-devtools/plugins/<%= cssModule %>",
-                            "files": "/css/**/*.css"
+                            "files": "/**/*.css"
                         },<% } %>
                         "copier": {
                             "module": "kraken-devtools/plugins/copier",


### PR DESCRIPTION
The default settings only watch for css files under the
```/css/**/.css path```
however, bower components by default go under /components, so to give default support for bower
it should be changed to 
```
/**/.css
```

This is always the first thing I change while starting new projects with kraken, so I figured it would a good default feature. 