### PR TITLE
Update generated test when no templates are specified

### DIFF
--- a/controller/templates/test.js
+++ b/controller/templates/test.js
@@ -35,7 +35,11 @@ describe('<%= fullroute %>', function () {
             .get('<%= fullroute %>')
             .expect(200)
             .expect('Content-Type', /html/)
-            .expect(/Hello, /)
+            <% if (hasTemplates) { %>
+                .expect(/Hello, /)
+            <% } else { %>
+                .expect(/"name": "index"/)
+            <% } %>
             .end(function (err, res) {
                 done(err);
             });


### PR DESCRIPTION
The test generated using templates/test.js fails when generating a project with no template engine.

This PR updates the test to match the output given here: https://github.com/flsafe/generator-kraken/blob/4b00756913b2da60b2c995caea2c2676222a2afc/controller/templates/controller.js#L28
