### PR TITLE
Support Phusion Passenger

### DIFF
--- a/app/templates/common/index.js
+++ b/app/templates/common/index.js
@@ -33,7 +33,7 @@ app.on('start', function () {
 /*
  * Create and start HTTP server.
  */
-if (!module.parent) {
+if (!module.parent || module.parent.isApplicationLoader) {
 
     /*
      * This is only done when this module is run directly, e.g. `node .` to allow for the


### PR DESCRIPTION
The default Kraken app doesn't work in [the Phusion Passenger application server](https://www.phusionpassenger.com). That's because index.js checks for 'module.parent'. Due to the way Phusion Passenger is implemented, 'module.parent' is not undefined.

This pull request adds support for Phusion Passenger by adding another check. This change has already been accepted by another Javascript framework, CompoundJS, which had a similar problem. [See the discussion here.](https://groups.google.com/forum/?fromgroups#!topic/compoundjs/4txxkNtROQg)

The mechanism used in this pull request is [documented here](https://github.com/phusion/passenger/blob/cae6c0df74d6c6ad08c8960f5735c6f6cb2a72cc/CHANGELOG#L403-L415).
