### PR TITLE
[Improvement] Added bower to peerDependencies.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Already familiar with the generator? [Skip right to the new stuff](#warning-new-
 ### Installation
 
 ```shell
-$ [sudo] npm install -g yo generator-kraken bower
+$ [sudo] npm install -g generator-kraken
 ```
  
 ### Usage

--- a/package.json
+++ b/package.json
@@ -25,9 +25,9 @@
     "coverage": "istanbul cover _mocha -- test/*.js"
   },
   "dependencies": {
-    "yeoman-generator": "^0.16.0",
     "chalk": "^0.4.0",
-    "update-notifier": "^0.1.7"
+    "update-notifier": "^0.1.7",
+    "yeoman-generator": "^0.16.0"
   },
   "devDependencies": {
     "grunt": "^0.4.2",
@@ -36,7 +36,8 @@
     "resolve": "^1.0.0"
   },
   "peerDependencies": {
-    "yo": ">=1.1.0"
+    "yo": ">=1.1.0",
+    "bower": "^1.3.12"
   },
   "engines": {
     "node": ">=0.8.0",


### PR DESCRIPTION
As of `yo` 1.x, peer dependencies can be directly managed by the generator itself. (See https://github.com/yeoman/generator/issues/305).

Currently we're asking users to install `yo` and `bower` along with the generator.  This PR simplifies things a bit by moving them to peerDependencies.

Users now only need to `[sudo] npm install generator-kraken` and they are set.
