### PR TITLE
Update readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,8 +77,6 @@ $ yo kraken
 ...
 ```
 
-<!-- To run your application, just go into the newly created directory and type `npm start`. -->
-
 To run your application, just go into the newly created directory and type these commands:
 
 ```shell
@@ -95,7 +93,7 @@ Listening on 8000
 To initialize bower run `bower init` then follow the commands.
 
 ```shell
-? name: (YourApplicationName) 
+? name: (YourApplicationName)
 ? version: (0.0.0)
 ? description:
 ? main file: (index.js)

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Already familiar with the generator? [Skip right to the new stuff](#warning-new-
 ```shell
 $ [sudo] npm install -g yo generator-kraken bower
 ```
- 
+
 ### Usage
 
 ```shell
@@ -77,10 +77,13 @@ $ yo kraken
 ...
 ```
 
-To run your application, just go into the newly created directory and type `npm start`.
+<!-- To run your application, just go into the newly created directory and type `npm start`. -->
+
+To run your application, just go into the newly created directory and type these commands:
 
 ```shell
 $ cd HelloWorld
+$ npm install
 $ npm start
 
 > helloworld@0.0.1 start ~/HelloWorld
@@ -89,6 +92,28 @@ $ npm start
 Listening on 8000
 ```
 
+To initialize bower run `bower init` then follow the commands.
+
+```shell
+? name: (YourApplicationName) 
+? version: (0.0.0)
+? description:
+? main file: (index.js)
+what types of modules does this package expose? (Press <space> to select)
+❯◯ amd
+ ◯ es6
+ ◯ globals
+ ◯ node
+ ◯ yui
+? keywords:
+? authors:
+? license: (MIT)
+? homepage:
+? set currently installed components as dependencies? (y/N)
+? add commonly ignored files to ignore list? (Y/n)
+? would you like to mark this package as private which prevents it from being accidentally published to the registry? (y/N)
+? Looks good? (Y/n)
+```
 
 ### Project Structure
 


### PR DESCRIPTION
As I brought up earlier in issue https://github.com/krakenjs/generator-kraken/issues/171 it would be nice to have the readme.md reflect what is currently needed to get running with this generator even if it is just a hot fix until you get everything sorted. 

I also included the list of steps for the bower file. Other generators like the angular-fullstack list out what the commands are that the generator will ask. It's nice to see this ahead of time and be able to go back and check later. I can remove it if you feel it is unnecessary however. 