### PR TITLE
Add construx plus some bug fixes

### DIFF
--- a/app/dependencies.js
+++ b/app/dependencies.js
@@ -136,11 +136,10 @@ module.exports = {
 
     stylus: {
         npm: [
-            'stylus@^0.42.3',
             'construx-stylus@^1.0.0'
         ],
         npmDev: [
-            'grunt-contrib-stylus@^0.13.2'
+            'grunt-contrib-stylus@^0.21.0'
         ],
         tasks: "stylus",
         templates: "stylus/**"

--- a/app/dependencies.js
+++ b/app/dependencies.js
@@ -114,11 +114,10 @@ module.exports = {
 
     less: {
         npm: [
-            'less@^1.6.1',
             'construx-less@^1.0.0'
         ],
         npmDev: [
-            'grunt-contrib-less@^0.9.0'
+            'grunt-contrib-less@^1.0.0'
         ],
         tasks: "less",
         templates: "less/**"
@@ -126,11 +125,10 @@ module.exports = {
 
     sass: {
         npm: [
-            'node-sass@^2.0.0',
             'construx-sass@^1.0.0'
         ],
         npmDev: [
-            'grunt-sass@^0.18.1'
+            'grunt-sass@^1.0.0'
         ],
         tasks: "sass",
         templates: "sass/**"

--- a/app/dependencies.js
+++ b/app/dependencies.js
@@ -45,14 +45,11 @@ module.exports = {
 
     i18n: {
         npm: function (options) {
-            var deps = [];
             if (options.templateModule === 'dustjs') {
-                deps.push('localizr@^0.1.2');
+                return 'localizr@^0.1.2';
             } else if (options.templateModule === 'makara') {
-                deps.push('dust-makara-helpers@^4.0.0');
-                deps.push('construx-dustjs@^1.0.0');
+                return 'dust-makara-helpers@^4.0.0';
             }
-            return deps;
         },
         npmDev: function (options) {
             if (options.templateModule === 'dustjs') {
@@ -87,7 +84,8 @@ module.exports = {
 
     "makara": {
         npm: [
-            'makara@^2.0.1'
+            'makara@^2.0.1',
+            'construx-dustjs@^1.0.0'
         ],
         npmDev: [
             'grunt-dustjs@^1.2.1'

--- a/app/dependencies.js
+++ b/app/dependencies.js
@@ -29,7 +29,8 @@ module.exports = {
             'dustjs-linkedin@~2.6.1',
             'dustjs-helpers@~1.6.1',
             "engine-munger@^0.2.5",
-            'adaro@^0.1.5'
+            'adaro@^0.1.5',
+            'construx-dustjs-i18n@^1.0.0'
         ],
         npmDev: [
             'grunt-dustjs@^1.2.1'
@@ -44,11 +45,14 @@ module.exports = {
 
     i18n: {
         npm: function (options) {
+            var deps = [];
             if (options.templateModule === 'dustjs') {
-                return 'localizr@^0.1.2';
+                deps.push('localizr@^0.1.2');
             } else if (options.templateModule === 'makara') {
-                return 'dust-makara-helpers@^4.0.0';
+                deps.push('dust-makara-helpers@^4.0.0');
+                deps.push('construx-dustjs@^1.0.0');
             }
+            return deps;
         },
         npmDev: function (options) {
             if (options.templateModule === 'dustjs') {
@@ -112,7 +116,8 @@ module.exports = {
 
     less: {
         npm: [
-            'less@^1.6.1'
+            'less@^1.6.1',
+            'construx-less@^1.0.0'
         ],
         npmDev: [
             'grunt-contrib-less@^0.9.0'
@@ -123,7 +128,8 @@ module.exports = {
 
     sass: {
         npm: [
-            'node-sass@^2.0.0'
+            'node-sass@^2.0.0',
+            'construx-sass@^1.0.0'
         ],
         npmDev: [
             'grunt-sass@^0.18.1'
@@ -134,7 +140,8 @@ module.exports = {
 
     stylus: {
         npm: [
-            'stylus@^0.42.3'
+            'stylus@^0.42.3',
+            'construx-stylus@^1.0.0'
         ],
         npmDev: [
             'grunt-contrib-stylus@^0.13.2'

--- a/app/templates/common/config/development.json
+++ b/app/templates/common/config/development.json
@@ -45,14 +45,23 @@
             "enabled": true,
             "priority": 35,
             "module": {
-                "name": "kraken-devtools",
+                "name": "construx",
                 "arguments": [
                     "path:./public",
                     "path:./.build",
                     {
                         <% if (templateModule === 'dustjs') { %>
                         "template": {
-                            "module": "kraken-devtools/plugins/dustjs",
+                            "module": "construx-dustjs-i18n",
+                            "files": "/templates/**/*.js",
+                            "base": "templates"
+                            <% if (i18n) { %>
+                            ,"i18n": "config:i18n"
+                            <% } %>
+                        },
+                        <% } else if (templateModule === 'makara') { %>
+                        "template": {
+                            "module": "construx-dustjs",
                             "files": "/templates/**/*.js",
                             "base": "templates",
                             "i18n": "config:i18n"
@@ -60,12 +69,12 @@
                         <% } %>
                         <% if (cssModule) { %>
                         "css": {
-                            "module": "kraken-devtools/plugins/<%= cssModule %>",
+                            "module": "construx-<%= cssModule %>",
                             "files": "/css/**/*.css"
                         },
                         <% } %>
                         "copier": {
-                            "module": "kraken-devtools/plugins/copier",
+                            "module": "construx-copier",
                             "files": "**/*"
                         }
                     }

--- a/app/templates/common/config/development.json
+++ b/app/templates/common/config/development.json
@@ -63,8 +63,7 @@
                         "template": {
                             "module": "construx-dustjs",
                             "files": "/templates/**/*.js",
-                            "base": "templates",
-                            "i18n": "config:i18n"
+                            "base": "templates"
                         },
                         <% } %>
                         <% if (cssModule) { %>

--- a/app/templates/common/package.json
+++ b/app/templates/common/package.json
@@ -11,7 +11,8 @@
     },
     "dependencies": {
         "kraken-js": "^1.0.3",
-        "kraken-devtools": "^1.2.1",
+        "construx": "^1.0.0",
+        "construx-copier": "^1.0.0",
         "express": "^4.12.2"
     },
     "devDependencies": {

--- a/app/templates/dependencies/dustjs/public/templates/errors/404.dust
+++ b/app/templates/dependencies/dustjs/public/templates/errors/404.dust
@@ -1,6 +1,6 @@
 {>"layouts/master" /}
 
 {<body}
-    <h1>{@pre type="content" key="header"/}</h1>
-    <p>{@pre type="content" key="description"/}</p>
+    <h1><% if (i18n) { %>{@pre type="content" key="header"/}<% } else { %>File not found<% } %></h1>
+    <p><% if (i18n) { %>{@pre type="content" key="description"/}<% } else { %>The URL <code>{url}</code> did not resolve to a route.<% } %></p>
 {/body}

--- a/app/templates/dependencies/dustjs/public/templates/errors/500.dust
+++ b/app/templates/dependencies/dustjs/public/templates/errors/500.dust
@@ -1,6 +1,6 @@
 {>"layouts/master" /}
 
 {<body}
-    <h1>{@pre type="content" key="header"/}</h1>
-    <p>{@pre type="content" key="description"/}</p>
+    <h1><% if (i18n) { %>{@pre type="content" key="header"/}<% } else { %>Internal server error<% } %></h1>
+    <p><% if (i18n) { %>{@pre type="content" key="description"/}<% } else { %>The URL <code>{url}</code> had the following error <code>{err}</code>.<% } %></p>
 {/body}

--- a/app/templates/dependencies/dustjs/public/templates/errors/503.dust
+++ b/app/templates/dependencies/dustjs/public/templates/errors/503.dust
@@ -1,6 +1,6 @@
 {>"layouts/master" /}
 
 {<body}
-    <h1>{@pre type="content" key="header"/}</h1>
-    <p>{@pre type="content" key="description"/}</p>
+    <h1><% if (i18n) { %>{@pre type="content" key="header"/}<% } else { %>Service unavailable<% } %></h1>
+    <p><% if (i18n) { %>{@pre type="content" key="description"/}<% } else { %>The service is unavailable. Please try back shortly.<% } %></p>
 {/body}

--- a/app/templates/dependencies/sass/tasks/sass.js
+++ b/app/templates/dependencies/sass/tasks/sass.js
@@ -2,22 +2,20 @@
 
 
 module.exports = function sass(grunt) {
-	// Load task
-	grunt.loadNpmTasks('grunt-sass');
+    // Load task
+    grunt.loadNpmTasks('grunt-sass');
 
-	// Options
-	return {
+    // Options
+    return {
         build: {
             options: {
                 outputStyle: 'compressed'
             },
-            files: [{
-                expand: true,
-                cwd: 'public/css',
-                src: ['**/*.scss'],
-                dest: '.build/css/',
-                ext: '.css'
-            }]
+            cwd: 'public/css',
+            src: '**/*.scss',
+            dest: '.build/css/',
+            expand: true,
+            ext: '.css'
         }
-	};
+    };
 };

--- a/layout/index.js
+++ b/layout/index.js
@@ -25,8 +25,14 @@ var debug = require('debuglog')('generator-kraken');
 module.exports = yeoman.generators.NamedBase.extend({
     init: function () {
         debug("layout");
+        this.config.defaults({
+            i18n: this.options.i18n
+        });
+
         // Create the corresponding locale as well
-        this.composeWith('kraken:locale', { args: this.args }, { local: require.resolve('../locale') });
+        if (this.config.get('i18n')) {
+            this.composeWith('kraken:locale', { args: this.args }, { local: require.resolve('../locale') } );
+        }
     },
 
     files: function files() {

--- a/layout/templates/layout.dust
+++ b/layout/templates/layout.dust
@@ -3,7 +3,7 @@
     <head>
         <meta charset="utf-8" />
         <title>{+title /}</title>
-    <% if (cssModule) { %>
+    <% if (i18n) { %>
         <link rel="stylesheet" href="/css/app.css">
     <% } %>
     </head>

--- a/layout/templates/layout.dust
+++ b/layout/templates/layout.dust
@@ -3,7 +3,7 @@
     <head>
         <meta charset="utf-8" />
         <title>{+title /}</title>
-    <% if (i18n) { %>
+    <% if (cssModule) { %>
         <link rel="stylesheet" href="/css/app.css">
     <% } %>
     </head>

--- a/template/index.js
+++ b/template/index.js
@@ -34,14 +34,12 @@ module.exports = yeoman.generators.NamedBase.extend({
         }
     },
 
-    writing: function files() {
+    files: function files() {
         debug("creating template '%s'", this.name);
         this.fs.copyTpl(
             this.templatePath('template.dust'),
             this.destinationPath(path.join('public', 'templates', this.name + '.dust')),
-            {
-                jsModule: this.options.jsModule
-            }
+            this.config.getAll()
         );
     }
 });

--- a/template/templates/template.dust
+++ b/template/templates/template.dust
@@ -1,5 +1,5 @@
 {>"layouts/master" /}
 
 {<body}
-    <h1>{@pre type="content" key="greeting"/}</h1>
+    <h1><% if (i18n) { %>{@pre type="content" key="greeting"/}<% } else { %>Hello, {name}<% } %></h1>
 {/body}

--- a/test/app-prompts.js
+++ b/test/app-prompts.js
@@ -152,7 +152,7 @@ describe('kraken:app', function () {
             ]);
 
             assert.fileContent([
-                ['package.json', new RegExp(/\"less\"\:/)],
+                ['package.json', new RegExp(/\"construx-less\"\:/)],
                 ['package.json', new RegExp(/\"grunt-contrib-less\"\:/)]
             ]);
 
@@ -175,7 +175,7 @@ describe('kraken:app', function () {
             ]);
 
             assert.fileContent([
-                ['package.json', new RegExp(/\"node-sass\"\:/)],
+                ['package.json', new RegExp(/\"construx-sass\"\:/)],
                 ['package.json', new RegExp(/\"grunt-sass\"\:/)]
             ]);
 
@@ -198,7 +198,7 @@ describe('kraken:app', function () {
             ]);
 
             assert.fileContent([
-                ['package.json', new RegExp(/\"stylus\"\:/)],
+                ['package.json', new RegExp(/\"construx-stylus\"\:/)],
                 ['package.json', new RegExp(/\"grunt-contrib-stylus\"\:/)]
             ]);
 

--- a/test/template.js
+++ b/test/template.js
@@ -31,6 +31,7 @@ describe('kraken:template', function () {
 
         base.args = ['Foo'];
         base.options.templateModule = 'dustjs';
+        base.options.i18n = false;
 
         testutil.run(base, function (err) {
             assert.file([


### PR DESCRIPTION
Consider a major release for this? Replaces `kraken-devtools` with `construx` and individual `construx-*` plugins.

Other changes:
* fixes #174 by replacing properties file based dust templates with inline content based dust templates
* fixes #164 by using `construx-sass` for development mode, and upgrades `grunt-sass` to the `node-sass@3.0` compatible version
* upgrades stylus support to `^0.50.0`
