### PR TITLE
Fixed failing unit test.  

### DIFF
--- a/test/app-prompts.js
+++ b/test/app-prompts.js
@@ -46,7 +46,7 @@ describe('kraken:app', function () {
                 'public/templates/errors/500.dust',
                 'public/templates/errors/503.dust',
                 'public/components/dustjs-linkedin/',
-                'public/components/dustjs-linkedin-helpers/',
+                'public/components/dustjs-helpers/',
                 'tasks/dustjs.js'
             ]);
 


### PR DESCRIPTION
It seems that dust helpers now install to
`dust-helpers`
instead of
`dust-linkedin-helpers`
