### PR TITLE
Add bower check

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -25,7 +25,8 @@ var path = require('path'),
     krakenutil = require('../util'),
     us = require('underscore.string');
 
-krakenutil.update();
+ krakenutil.bowerCheck();
+ krakenutil.update();
 
 var debug = require('debuglog')('generator-kraken');
 

--- a/test/app-prompts.js
+++ b/test/app-prompts.js
@@ -46,7 +46,7 @@ describe('kraken:app', function () {
                 'public/templates/errors/500.dust',
                 'public/templates/errors/503.dust',
                 'public/components/dustjs-linkedin/',
-                'public/components/dustjs-linkedin-helpers/',
+                'public/components/dustjs-helpers/',
                 'tasks/dustjs.js'
             ]);
 

--- a/util/bowerCheck.js
+++ b/util/bowerCheck.js
@@ -1,4 +1,4 @@
- /*───────────────────────────────────────────────────────────────────────────*\
+/*───────────────────────────────────────────────────────────────────────────*\
  │  Copyright (C) 2014 eBay Software Foundation                                │
  │                                                                             │
  │hh ,'""`.                                                                    │
@@ -16,10 +16,35 @@
  │   limitations under the License.                                            │
  \*───────────────────────────────────────────────────────────────────────────*/
 'use strict';
+var cp = require('child_process'),
+    chalk = require('chalk');
 
+/**
+ * This function simply emits a warning message if bower is unavailable.
+ */
+module.exports = function bowerCheck() {
 
-exports.banner = require('./banner');
-exports.update = require('./update');
-exports.validate = require('./validate');
-exports.extend = require('./extend');
-exports.bowerCheck = require('./bowerCheck');
+    var alreadyWarned;
+
+    function warn() {
+        alreadyWarned || console.error(chalk.red.bold('Warning:') + ' Bower not found. This may cause issues.\nHave you installed bower globally? (npm install bower --global)');
+        alreadyWarned = true;
+    };
+
+    try {
+        var process = cp.spawn('bower', ['-v']);
+        //It's async, but since I just want to display a warning, I don't care much.
+        process.on('close', function (status) {
+            if (status !== 0) {
+                warn();
+            }
+        });
+
+        process.on('error', function () {
+            warn();
+        })
+    }
+    catch (err) {
+        warn();
+    }
+};


### PR DESCRIPTION
A lot of people don't read the documentation (gasp!) and don't install bower.
This PR does a quick check for its presence, and shows a warning if it's not there.

I considered killing the process, but it seemed excessive.

If bower is not available, it will show as:
![No Bower](https://camo.githubusercontent.com/d2222b347fd759016c3284b2fe2394b70b731855/687474703a2f2f692e696d6775722e636f6d2f784e6f526e78422e706e67)