### PR TITLE
Make Dust templates render without whitespace suppression on developm…

### DIFF
--- a/app/templates/common/config/development.json
+++ b/app/templates/common/config/development.json
@@ -31,7 +31,11 @@
             "renderer": {
                 "method": "dust",
                 "arguments": [
-                    { "cache": false, "helpers": "config:dust.helpers" }
+                    {
+                        "cache": false,
+                        "helpers": "config:dust.helpers",
+                        "whitespace": true
+                    }
                 ]
             }
         }


### PR DESCRIPTION
…ent mode.

In reference to issues like: https://github.com/krakenjs/kraken-js/issues/438 it's useful for developers to see
the direct output of their in-progress work, with no minification / obfuscation, as this helps debugging.

This commit changes the default behavior of the dust engine (In development mode) so that it renders templates as-is, without removing whitespace.
Production mode will continue to be optimized as it is today.