### PR TITLE
Fix minor bug that prevents the app name from being read directly from CLI

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -30,9 +30,9 @@ krakenutil.update();
 var debug = require('debuglog')('generator-kraken');
 
 module.exports = yeoman.generators.Base.extend({
-    init: function () {
+    initializing: function () {
         krakenutil.banner();
-
+        // Read app name from CLI
         this.argument('name', { type: String, required: false });
     },
 


### PR DESCRIPTION


"initializing" is the right name for the first priority function in the yeoman run loop