### PR TITLE
fix error messages related to missing bower.json file

### DIFF
--- a/app/templates/dependencies/bower/bower.json
+++ b/app/templates/dependencies/bower/bower.json
@@ -1,0 +1,18 @@
+{
+  "name": "<%= slugName %>",
+  "description": "<%= description.replace(/"/g, '\\"') %>",
+  "main": "index.js",
+  "author": "<%= author.replace(/"/g, '\\"') %>",
+  "moduleType": [
+    "<% if (jsModule === 'requirejs') { %>amd<% } else { %>node<% } %>"
+  ],
+  "private": true,
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "public/components",
+    "test",
+    "tests"
+  ]
+}


### PR DESCRIPTION
When selecting "bower" for package management, lack of a `bower.json` file causes a ENOENT error during the installation process. This doesn't kill the generator or prevent a working app from being installed, but it does cause a couple of error messages in the log. It could possibly kill the process in a different environment than I have.