### PR TITLE
Fix.no.bower.no.requirejs

### DIFF
--- a/app/dependencies.js
+++ b/app/dependencies.js
@@ -146,16 +146,30 @@ module.exports = {
     },
 
     requirejs: {
-        bower: [
-            'requirejs#^2.1.16'
-        ],
+        bower: function (options) {
+            if (options.componentPackager === 'bower') {
+                return 'requirejs#^2.1.16';
+            }
+            return false;
+        },
         npm: [
             'requirejs@^2.1.16'
         ],
-        npmDev: [
-            'grunt-contrib-requirejs@^0.4.4'
-        ],
+        npmDev: function (options) {
+            var deps = ['grunt-contrib-requirejs@^0.4.4'];
+            if (options.componentPackager !== 'bower') {
+                deps.push('grunt-copy-browser-modules@^5.0.1');
+            }
+            return deps;
+        },
         tasks: "requirejs",
+        postInstallTasks: function (options) {
+            var tasks = [];
+            if (options.componentPackager !== 'bower') {
+                tasks.push('copy-browser-modules')
+            }
+            return tasks;
+        },
         templates: "requirejs/**"
     },
 

--- a/app/index.js
+++ b/app/index.js
@@ -216,10 +216,8 @@ module.exports = yeoman.generators.Base.extend({
             if (this.options['skip-install-bower']) {
                 return;
             }
-
             var dependencies = this._dependencyResolver('bower');
-            console.log('bower dependencies', dependencies);
-            if (dependencies !== null) {
+            if (dependencies) {
                 this.bowerInstall(dependencies, { save: true });
             }
         }

--- a/app/templates/common/Gruntfile.js
+++ b/app/templates/common/Gruntfile.js
@@ -21,5 +21,9 @@ module.exports = function (grunt) {
         return "'" + task + "'";
     }).join(', '); %>]);
     grunt.registerTask('test', [ 'jshint', 'mochacli' ]);
-
+    <% if (postInstallTasks.length > 0) { %>
+    grunt.registerTask('postinstall', [<%- postInstallTasks.map(function (task) {
+          return "'" + task + "'";
+      }).join(', '); %>]);
+    <% } -%>
 };

--- a/app/templates/common/package.json
+++ b/app/templates/common/package.json
@@ -8,6 +8,9 @@
         "test": "grunt test",
         "build": "grunt build",
         "all": "npm run build && npm run test"
+        <% if (componentPackager !== 'bower' && jsModule === 'requirejs') { %>
+        ,"postinstall": "grunt postinstall"
+        <% } %>
     },
     "dependencies": {
         "kraken-js": "^1.0.3",
@@ -19,4 +22,13 @@
         "mocha": "^1.18.0",
         "supertest": "^0.9.0"
     }
+    <% if (componentPackager !== 'bower' && jsModule === 'requirejs') { %>
+    ,"browserPackage": {
+        "overrides": {
+            "requirejs": {
+                "main": "require"
+            }
+        }
+    }
+    <% } %>
 }

--- a/app/templates/common/tasks/copy-browser-modules.js
+++ b/app/templates/common/tasks/copy-browser-modules.js
@@ -1,0 +1,13 @@
+'use strict';
+
+module.exports = function dustjs(grunt) {
+  grunt.loadNpmTasks('grunt-copy-browser-modules');
+
+  return {
+    build: {
+      root: process.cwd(),
+      dest: 'public/components',
+      basePath: 'public'
+    }
+  };
+};

--- a/app/templates/dependencies/bower/bower.json
+++ b/app/templates/dependencies/bower/bower.json
@@ -1,0 +1,18 @@
+{
+  "name": "<%= slugName %>",
+  "description": "<%= description.replace(/"/g, '\\"') %>",
+  "main": "index.js",
+  "author": "<%= author.replace(/"/g, '\\"') %>",
+  "moduleType": [
+    "<% if (jsModule === 'requirejs') { %>amd<% } else { %>node<% } %>"
+  ],
+  "private": true,
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "public/components",
+    "test",
+    "tests"
+  ]
+}

--- a/test/app-build.js
+++ b/test/app-build.js
@@ -37,8 +37,10 @@ describe('kraken:app', function () {
         base.prompt.i18n = 'i18n';
 
         testutil.run(base, function (err) {
-            if (err) { return done(err); }
-            var build = require('child_process').spawn('npm', ['run', 'all'], { stdio: 'inherit' });
+            if (err) {
+                return done(err);
+            }
+            var build = require('child_process').spawn('npm', ['run', 'all'], {stdio: 'inherit'});
 
             build.on('close', function (code) {
                 assert.strictEqual(code, 0);
@@ -55,8 +57,10 @@ describe('kraken:app', function () {
         base.prompt.i18n = 'i18n';
 
         testutil.run(base, function (err) {
-            if (err) { return done(err); }
-            var build = require('child_process').spawn('npm', ['run', 'all'], { stdio: 'inherit' });
+            if (err) {
+                return done(err);
+            }
+            var build = require('child_process').spawn('npm', ['run', 'all'], {stdio: 'inherit'});
 
             build.on('close', function (code) {
                 assert.strictEqual(code, 0);
@@ -80,8 +84,10 @@ describe('kraken:app', function () {
         env.NODE_ENV = 'production';
 
         testutil.run(base, function (err) {
-            if (err) { return done(err); }
-            var build = require('child_process').spawn('npm', ['run', 'all'], { stdio: 'inherit', env: env });
+            if (err) {
+                return done(err);
+            }
+            var build = require('child_process').spawn('npm', ['run', 'all'], {stdio: 'inherit', env: env});
 
             build.on('close', function (code) {
                 assert.strictEqual(code, 0);
@@ -89,7 +95,45 @@ describe('kraken:app', function () {
             });
         });
     });
+    it('scaffolded application with no bower using requirejs runs postinstall task', function (done) {
+        var base = testutil.makeBase('app');
 
+        base.options['skip-install'] = false;
+        base.prompt.templateModule = 'makara';
+        base.prompt.i18n = 'i18n';
+        base.prompt.componentPackager = false;
+        base.prompt.jsModule = 'requirejs';
+
+
+        var env = {};
+        for (var v in process.env) {
+            env[v] = process.env[v];
+        }
+
+        testutil.run(base, function (err) {
+            if (err) {
+                return done(err);
+            }
+            var build = require('child_process').spawn('npm', ['run', 'all'], {stdio: 'inherit', env: env});
+
+            build.on('close', function (code) {
+                assert.file([
+                    'public/components/requirejs/require.js',
+                    'tasks/copy-browser-modules.js'
+                ]);
+                assert.noFile([
+                    '.bowerrc'
+                ]);
+                assert.fileContent([
+                    ['package.json', new RegExp(/(browserPackage)/)],
+                    ['package.json', new RegExp(/(overrides)/)],
+                    ['Gruntfile.js', new RegExp(/(postinstall.+copy\-browser\-modules)/)]
+                ]);
+                assert.strictEqual(code, 0);
+                done(err);
+            });
+        });
+    });
     it('scaffolded application does not suffer from dll hell with dust-helpers', function (done) {
         var base = testutil.makeBase('app');
 

--- a/test/app-prompts.js
+++ b/test/app-prompts.js
@@ -70,6 +70,7 @@ describe('kraken:app', function () {
         base.prompt['cssModule'] = false;
         base.prompt['i18n'] = false;
         base.prompt['jsModule'] = false;
+        base.prompt['componentPackager'] = false;
 
         testutil.run(base, function (err) {
 

--- a/test/util/makeBase.js
+++ b/test/util/makeBase.js
@@ -27,6 +27,7 @@ module.exports = function makeBase(generator) {
             'description': 'This is an app, foo!',
             'author': 'Jeff',
             'templateModule': 'dustjs',
+            'componentPackager': 'bower',
             'cssModule': false,
             'jsModule': false,
             'taskModule': 'grunt'


### PR DESCRIPTION
To make requirejs work in the non-bower case:
* modified requirejs "dependencies" object, for the non-bower case, to use "copy-browser-modules" instead and to add a new postInstall task for insertion to Gruntfile
* adding the browserPackage override in package.json to instruct "copy-browser-modules" what is the main require.js file

To remove little bower errors when bower is used:
* add a bower.json els file to copy to project when bower is selected

To remove little bower errors when bower is not used:
* add a bower true/false flag to the installDependencies call

To ensure that the postinstall task runs after all dependencies are installed:
* move the installDependencies call after the other dependency installation methods.

This PR subsumes #202