### PR TITLE
Fix.generated.controller.tests

### DIFF
--- a/controller/templates/test.js
+++ b/controller/templates/test.js
@@ -31,7 +31,7 @@ describe('<%= name %>', function () {
     });
 
 
-    it('<% if (templateModule) {%>should say "hello"<% } else {%>should have model name "<%= name %>"<%}%>', function (done) {
+    it('<% if (templateModule) { %>should say "hello"<% } else { %>should have model name "<%= name %>"<% } %>', function (done) {
         request(mock)
             .get('<%= route %>')
             .expect(200)

--- a/controller/templates/test.js
+++ b/controller/templates/test.js
@@ -31,7 +31,7 @@ describe('<%= name %>', function () {
     });
 
 
-    it('should say "hello"', function (done) {
+    it('<% if (templateModule) {%>should say "hello"<% } else {%>should have model name "<%= name %>"<%}%>', function (done) {
         request(mock)
             .get('<%= route %>')
             .expect(200)
@@ -39,7 +39,7 @@ describe('<%= name %>', function () {
             <% if (templateModule) { %>
                 .expect(/Hello, /)
             <% } else { %>
-                .expect(/"name": "index"/)
+                .expect(/"name": "<%= name %>"/)
             <% } %>
             .end(function (err, res) {
                 done(err);


### PR DESCRIPTION
Fixes #161 

* uses name property to dynamically generate assertion comparison in the "no template engine" use case
* adds name property to the test case name